### PR TITLE
Load hey.cli module only when config was requested

### DIFF
--- a/hey/__main__.py
+++ b/hey/__main__.py
@@ -11,7 +11,6 @@ from rich.progress import Progress, SpinnerColumn, TextColumn
 
 from . import api
 from .config import Config, load_config
-from .cli import run_config
 
 
 @click.command(context_settings={"ignore_unknown_options": True})
@@ -38,6 +37,7 @@ def cli(args: tuple[str, ...], agree_tos: bool, verbose: bool, prompt: str | Non
         hey config
     """
     if len(args) == 1 and args[0] == "config":
+        from .cli import run_config
         run_config()
         return
 


### PR DESCRIPTION
The `hey.cli` module uses `InquirerPy` which is pretty heavy to load. On RPi4 simple `time hey --help` shows that by postponing this module load we can save 200 ms startup time.

Before:

```
~/hey-py $ time hey --help >/dev/null
real    0m1.123s
user    0m1.026s
sys     0m0.096s
```

After:

```
~/hey-py $ time hey --help >/dev/null
real    0m0.866s
user    0m0.794s
sys     0m0.072s
```